### PR TITLE
Fix writing binseq to stdout from encode

### DIFF
--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -142,7 +142,7 @@ pub struct OutputBinseq {
         short = 'o',
         long,
         help = "Output binseq file [default: stdout]",
-        required_unless_present = "pipe"
+        required = false,
     )]
     pub output: Option<String>,
 


### PR DESCRIPTION
Hi, the help message for `encode` claims that without -o/--output the results are written to stdout but the tool doesn't actually allow that unless the input is piped in. I don't know what behaviour was intended for bqtools, but outputting to stdout can be enabled by changing `required_unless_present = "pipe"` to `required = false` in the CLI which I've done here.